### PR TITLE
Update to long product description in quote details example

### DIFF
--- a/docs/code_examples/Quote/retrieving_your_quote_details.json
+++ b/docs/code_examples/Quote/retrieving_your_quote_details.json
@@ -10,7 +10,7 @@
       "price": 1654,
       "arrivalDate": "2021-12-14T00:00:00+00:00",
       "lineItemId": "b91v-vfds",
-      "productDescription": " Material: Pvc Frontlit,  Banners Finishing: No Finishing,  Printing Process: Digital,  Delivery Type: Normal,  Custom width: 100,  Custom height: 100,  Printing Colors: 4/0 Full Color,",
+      "productDescription": "Material: Pvc Frontlit,  Banners Finishing: No Finishing.........",
       "vatPercentage": 21,
       "vatAmount": 347,
       "lineItemNumber": "Q63-1"


### PR DESCRIPTION
This change will fix the (to) long line length for the quote detail page.

![image](https://github.com/user-attachments/assets/ccecf660-f17b-4251-9569-a5b6dbe8baf9)
